### PR TITLE
ci: update action versions to use node 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Node 16.x
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 16
 


### PR DESCRIPTION
## Summary
Node 16 is EOL, upgrade action versions to use node 20

## Release Notes
* actions/checkout v3 -> v4: https://github.com/actions/checkout/releases/tag/v4.0.0
* actions/setup-node v3 -> v4: https://github.com/actions/setup-node/releases/tag/v4.0.0